### PR TITLE
cmd_file default to run_riboviz_vignette.sh

### DIFF
--- a/docs/run-vignette.md
+++ b/docs/run-vignette.md
@@ -447,18 +447,18 @@ If you have already generated hisat2 indices for the same organism and annotatio
 
 ## View commands submitted to bash
 
-`prep_riboviz.py` extracts configuration information from its configuration file and uses this information to execute the RiboViz operations, which are invocations of RiboViz-specific and third-party tools. These operations are invoked as bash commands submitted by `prep_riboviz.py`. To help with debugging, these commands are output into a command file (default name `prep_riboviz.sh`).
+`prep_riboviz.py` extracts configuration information from its configuration file and uses this information to execute the RiboViz operations, which are invocations of RiboViz-specific and third-party tools. These operations are invoked as bash commands submitted by `prep_riboviz.py`. To help with debugging, these commands are output into a command file (default name `run_riboviz_vignette.sh`).
 
 The name and location of this command file can be changed by editing the `cmd_file` parameter within the configuration file (e.g. within `vignette/vignette_config.yaml`):
 
 ```yaml
-cmd_file: prep_riboviz.sh # File to log	bash commands
+cmd_file: run_riboviz_vignette.sh # File to log	bash commands
 ```
 
 The command file can be run standalone, for example:
 
 ```yaml
-bash prep_riboviz.sh
+bash run_riboviz_vignette.sh
 ```
 
 ---

--- a/riboviz/tools/prep_riboviz.py
+++ b/riboviz/tools/prep_riboviz.py
@@ -59,8 +59,7 @@ Exit codes are as follows:
 * EXIT_COLLATION_ERROR (5): Error occurred during TPMs collation.
 
 Commands that are submitted to bash are recorded within a
-file specified by a cmd_file configuration parameter, default
-prep_riboviz.sh.
+file specified by a cmd_file configuration parameter.
 
 If --dry-run is provided then the commands submitted to bash will not
 be executed. This can be useful for seeing what commands will be run
@@ -448,7 +447,7 @@ def prep_riboviz(py_scripts, r_scripts, config_yaml, dry_run=False):
     if "cmd_file" in config:
         cmd_file = config["cmd_file"]
     else:
-        cmd_file = "prep_riboviz.sh"
+        cmd_file = "run_riboviz_vignette.sh"
     LOGGER.info("Command file: %s", cmd_file)
     if os.path.exists(cmd_file):
         os.remove(cmd_file)

--- a/vignette/vignette_config.yaml
+++ b/vignette/vignette_config.yaml
@@ -2,7 +2,7 @@ dir_in: vignette/input # input directory
 dir_out: vignette/output # output directory
 dir_tmp: vignette/tmp # tmp directory for intermediate files
 dir_logs: vignette/logs # log files directory
-cmd_file: prep_riboviz.sh # File to log bash commands
+cmd_file: run_riboviz_vignette.sh # File to log bash commands
 rRNA_fasta: vignette/input/yeast_rRNA_R64-1-1.fa # rRNA file to avoid aligning to
 orf_fasta: vignette/input/yeast_YAL_CDS_w_250utrs.fa # orf file to align to
 orf_gff_file: vignette/input/yeast_YAL_CDS_w_250utrs.gff3 # GFF2/GFF3 file for ORFs


### PR DESCRIPTION
Command file cmd_file defaults to `run_riboviz_vignette.sh`, because it runs riboviz pipeline instead of preparing a run. since we had a (deprecated) pipeline preparing bash script called `prep_riboviz.sh`, we should give a different and unambiguous name to the run script.

This is a minor edit to issue #63 and pull request #71 .