### PR TITLE
usage docs for check_fasta_gff.py, fixes #242

### DIFF
--- a/riboviz/check_fasta_gff.py
+++ b/riboviz/check_fasta_gff.py
@@ -8,11 +8,14 @@ import gffutils
 
 def check_fasta_gff(fasta, gff):
     """
-    Check FASTA and GFF files for compatibility. Check that:
+    Check FASTA and GFF files for coding sequence (CDS) features.
+    
+    Check that, for every CDS annotated in the GFF:
 
-    * The beginning of every CDS is a start codon (ATG; translates to
+    * The CDS has length divisible by 3.
+    * The beginning of the CDS is a start codon (ATG; translates to
       ``M``).
-    * The stop of every CDS is a stop codon (TAG, TGA, TAA; translates
+    * The stop of the CDS is a stop codon (TAG, TGA, TAA; translates
       to ``*``)
     * There are no stop codons internal to the CDS.
 

--- a/riboviz/tools/check_fasta_gff.py
+++ b/riboviz/tools/check_fasta_gff.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """
-Check FASTA and GFF files for compatibility.
+Check FASTA and GFF files for coding sequence (CDS) features.
 
 Usage::
 
-    python -m riboviz.tools.check_fasta_gff.py [-h] -f FASTA -g GFF
+    python -m riboviz.tools.check_fasta_gff [-h] -f FASTA -g GFF
 
     -h, --help            show this help message and exit
     -f FASTA, --fasta FASTA


### PR DESCRIPTION
* removed `.py` from usage in docstring in `tools/check_fasta_gff.py` (#242)
* edited docstrings in `tools/check_fasta_gff.py` and `check_fasta_gff.py` to say "Check FASTA and GFF files for coding sequence (CDS) features." Replaces previous vaguer statement on "compatibility".