### PR TITLE
Investigate check_fasta_gff performance 318

### DIFF
--- a/docs/reference/references.md
+++ b/docs/reference/references.md
@@ -46,6 +46,8 @@ Sievert, S. (2018) plotly for R. https://plotly-r.com/
 
 pycodestyle, https://github.com/pycqa/pycodestyle/
 
+Shirley, M.D., Ma, Z., Pedersen, B., Wheelan, S. (2015) Efficient "pythonic" access to FASTA iles using pyfaidx. PeerJ PrePrints 3:e1196. 2015. doi: (10.7287/peerj.preprints.970](https://doi.org/10.7287/peerj.preprints.970).
+
 pylint, https://www.pylint.org/
 
 pytest, https://github.com/pytest-dev/pytest/

--- a/riboviz/check_fasta_gff.py
+++ b/riboviz/check_fasta_gff.py
@@ -7,6 +7,7 @@ import os
 import warnings
 from Bio import SeqIO
 import gffutils
+from pyfaidx import Fasta
 from pyfaidx import FastaIndexingError
 from riboviz.fasta_gff import CDS_FEATURE_FORMAT
 from riboviz.fasta_gff import START_CODON
@@ -230,6 +231,7 @@ def get_issues(fasta,
     # Track sequences encountered and counts of features for
     # each.
     sequence_features = {}
+    fasta_genes = Fasta(fasta)
     for feature in gffdb.features_of_type('CDS'):
         if feature.seqid not in sequence_features:
             sequence_features[feature.seqid] = 0
@@ -248,7 +250,7 @@ def get_issues(fasta,
             issues.append((feature.seqid, feature_id_name,
                            NO_ID_NAME, None))
         try:
-            sequence = feature.sequence(fasta)
+            sequence = feature.sequence(fasta_genes)
         except KeyError as e:  # Missing sequence.
             issues.append((feature.seqid,
                            NOT_APPLICABLE,
@@ -380,7 +382,7 @@ def run_fasta_gff_check(fasta,
     * Metadata:
         - :py:const:`NUM_SEQUENCES`: number of sequences in ``fasta``.
         - :py:const:`NUM_FEATURES`: number of features in ``gff``.
-        - :py:const:`NUM_CDS_FEATURE`: number of ``CDS`` features in 
+        - :py:const:`NUM_CDS_FEATURE`: number of ``CDS`` features in
           ``gff``.
 
     :param fasta: FASTA file

--- a/riboviz/get_cds_codons.py
+++ b/riboviz/get_cds_codons.py
@@ -6,6 +6,7 @@ import csv
 import os
 import warnings
 import gffutils
+from pyfaidx import Fasta
 from riboviz import provenance
 from riboviz.fasta_gff import CDS_FEATURE_FORMAT
 
@@ -78,8 +79,8 @@ def get_cds_from_fasta(feature, fasta):
 
     :param feature: GFF feature for the CDS
     :type feature: gffutils.feature.Feature
-    :param fasta: FASTA file
-    :type fasta: str or unicode
+    :param fasta: FASTA genes
+    :type fasta: pyfaidx.Fasta
     :return: sequence
     :rtype: str or unicode
     :raises AssertionError: If sequence has length not divisible by 3
@@ -163,9 +164,10 @@ def get_cds_codons_from_fasta(fasta,
         raise ValueError("{} ({})".format(e, gff)) from e
     cds_codons = {}
     same_feature_id_count = 0
+    fasta_genes = Fasta(fasta)
     for feature in gffdb.features_of_type('CDS'):
         try:
-            sequence = get_cds_from_fasta(feature, fasta)
+            sequence = get_cds_from_fasta(feature, fasta_genes)
             codons = sequence_to_codons(sequence)
         except KeyError as e:  # Missing sequence.
             warnings.warn(str(e))
@@ -198,7 +200,7 @@ def write_feature_codons_to_csv(feature_codons, csv_file, delimiter="\t"):
     * :py:const:`GENE`: feature name.
     * :py:const:`POS`: codon position in coding sequence (1-indexed).
     * :py:const:`CODON`: codon.
-    
+
     :param feature_codons: Codons for each feature, keyed by feature \
     name
     :type feature_codons: dict(str or unicode -> list(str or unicode))


### PR DESCRIPTION
Fixes #318.

Changed use of gffutils.Feature.sequence to pass in pre-created `pyfaidx.Fasta` object instead of filename i.e. from use of:

```python
sequence = feature.sequence(fasta)
```

where FASTA file name is passed to `Feature.sequence` to use of:

```python
fasta_genes = Fasta(fasta)
```
and:
```python
sequence = feature.sequence(fasta_genes)
```

where `pyfaidx.Fasta` index on the FASTA file is used. This yields significantly better performance when repeatedly accessing sequences in the FASTA file when extracting the sequence corresponding to each feature in a GFF file, as done in `riboviz.check_fasta_gff.check_issues` and `riboviz.get_cds_codons.get_cds_codons_from_fasta`.

Added pyfaidx citation to docs/reference/references.md.