### PR TITLE
Fixed bug in prep_riboviz.nf viz_params construction

### DIFF
--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1326,16 +1326,16 @@ process countReads {
 
 Map viz_params = [:]
 if (is_asite_disp_length_file) {
-    viz_params.asite_disp_length_file = asite_disp_length_file
+    viz_params.asite_disp_length_file = asite_disp_length_file.toString()
 }
 if (is_codon_positions_file) {
-    viz_params.codon_positions_file = codon_positions_file
+    viz_params.codon_positions_file = codon_positions_file.toString()
 }
 if (is_features_file) {
-    viz_params.features_file = features_file
+    viz_params.features_file = features_file.toString()
 }
 if (is_t_rna_file) {
-    viz_params.t_rna_file = t_rna_file
+    viz_params.t_rna_file = t_rna_file.toString()
 }
 viz_params_yaml = new Yaml().dump(viz_params)
 


### PR DESCRIPTION
I noted that the YAML file constructed by `staticHTML` had object names not file paths i.e.

```console
$ cat work/4d/130b4e08bdcc0ce31ec2227379447b/config.yaml
asite_disp_length_file: !!sun.nio.fs.UnixPath {}
codon_positions_file: !!sun.nio.fs.UnixPath {}
features_file: !!sun.nio.fs.UnixPath {}
t_rna_file: !!sun.nio.fs.UnixPath {}
```
Changing `prep_riboviz.nf` from:
```
Map viz_params = [:]
if (is_asite_disp_length_file) {
    viz_params.asite_disp_length_file = asite_disp_length_file
}
if (is_codon_positions_file) {
    viz_params.codon_positions_file = codon_positions_file
}
if (is_features_file) {
    viz_params.features_file = features_file
}
if (is_t_rna_file) {
    viz_params.t_rna_file = t_rna_file
}
```
to
```
Map viz_params = [:]
if (is_asite_disp_length_file) {
    viz_params.asite_disp_length_file = asite_disp_length_file.toString()
}
if (is_codon_positions_file) {
    viz_params.codon_positions_file = codon_positions_file.toString()
}
if (is_features_file) {
    viz_params.features_file = features_file.toString()
}
if (is_t_rna_file) {
    viz_params.t_rna_file = t_rna_file.toString()
}
```
yields a YAML file with the expected paths e.g.
```console
$ cat work/9a/c76bfdac711b068157bf2d0718ac23/config.yaml
{asite_disp_length_file: /home/ubuntu/riboviz/data/yeast_standard_asite_disp_length.txt,
  codon_positions_file: /home/ubuntu/riboviz/data/yeast_codon_pos_i200.RData, features_file: /home/ubuntu/riboviz/data/yeast_features.tsv,
  t_rna_file: /home/ubuntu/riboviz/data/yeast_tRNAs.tsv}
```