### PR TITLE
Pdf optional 317

### DIFF
--- a/docs/user/prep-riboviz-config.md
+++ b/docs/user/prep-riboviz-config.md
@@ -82,6 +82,7 @@ The workflow also supports the following configuration parameters. All directory
 | `orf_fasta_file` | Transcript sequences file containing both coding regions and flanking regions (FASTA file) | Yes | |
 | `orf_gff_file` | Matched genome feature file, specifying coding sequences locations (start and stop coordinates) within the transcripts (GTF/GFF3 file) | Yes | |
 | `orf_index_prefix` | Prefix for ORF index files, relative to `<dir_index>` | Yes | |
+| `output_pdfs` | Generate .pdfs for sample-related plots | No | `true` |
 | `primary_id` | Primary gene IDs to access the data (YAL001C, YAL003W, etc.) | No | `Name` |
 | `publish_index_tmp` | Publish index and temporary files to `<dir_index>` and `<dir_tmp>`? If `true` copy index and temporary files from Nextflow's `work/` directory, else use symbolic links only (see [Nextflow `work/` directory](../user/prep-riboviz-operation.md#nextflow-work-directory)). | No | `false` |
 | `rpf` | Is the dataset an RPF or mRNA dataset? | No | `true` |
@@ -90,7 +91,6 @@ The workflow also supports the following configuration parameters. All directory
 | `samsort_memory` | Memory to give to `samtools sort`  | No | `null` (`samtools sort` uses built-in default `768M`, [samtools sort](http://www.htslib.org/doc/samtools-sort.html)) |
  | `sample_sheet` | A sample sheet, relative to `<dir_in>` (tab-separated values file) | Only if `multiplex_fq_files` is provided | |
 | `secondary_id` | Secondary gene IDs to access the data (COX1, EFB1, etc. or `NULL`) | No | `NULL` |
-<<<<<< HEAD
 | `skip_inputs` | When validating configuration (see `validate_only` below) skip checks for existence of ribosome profiling data files (`fq_files`, `multiplexed_fq_files`, `sample_sheet`)?  | No | `false` |
 | `stop_in_cds` | Are stop codons part of the CDS annotations in GFF? Used by `bam_to_h5.R` only (and only if `is_riboviz_gff` is `false`). Note: this parameter is now deprecated by `stop_in_feature` and will be removed in a future release. If both `stop_in_feature` and `stop_in_cds` are defined then `stop_in_feature` takes precedence. | No | `false` |
 | `stop_in_feature` | Are stop codons part of the feature annotations in GFF? If not provided and `stop_in_cds` is provided then the value of `stop_in_cds` is used for `stop_in_feature`. If both `stop_in_feature` and `stop_in_cds` are defined then `stop_in_feature` takes precedence. | No | `false` |
@@ -240,18 +240,18 @@ For example, `vignette/vignette_config.yaml` assumes the following structure of 
 
 ```
 data/
-  yeast_CDS_w_250utrs.fa 
-  yeast_CDS_w_250utrs.gff3 
-  yeast_codon_pos_i200.RData 
-  yeast_features.tsv 
-  yeast_standard_asite_disp_length.txt 
-  yeast_tRNAs.tsv 
+  yeast_CDS_w_250utrs.fa
+  yeast_CDS_w_250utrs.gff3
+  yeast_codon_pos_i200.RData
+  yeast_features.tsv
+  yeast_standard_asite_disp_length.txt
+  yeast_tRNAs.tsv
 vignette/
   input/
-    SRR1042855_s1mi.fastq.gz 
-    SRR1042864_s1mi.fastq.gz 
-    yeast_rRNA_R64-1-1.fa 
-    yeast_YAL_CDS_w_250utrs.fa 
+    SRR1042855_s1mi.fastq.gz
+    SRR1042864_s1mi.fastq.gz
+    yeast_rRNA_R64-1-1.fa
+    yeast_YAL_CDS_w_250utrs.fa
     yeast_YAL_CDS_w_250utrs.gff3
 ```
 
@@ -273,17 +273,17 @@ Create symbolic links to all the input files, where `$HOME/riboviz` is the path 
 
 ```console
 $ cd example/data
-$ ln -s $HOME/riboviz/data/yeast_CDS_w_250utrs.fa 
-$ ln -s $HOME/riboviz/data/yeast_CDS_w_250utrs.gff3 
-$ ln -s $HOME/riboviz/data/yeast_codon_pos_i200.RData 
-$ ln -s $HOME/riboviz/data/yeast_features.tsv 
-$ ln -s $HOME/riboviz/data/yeast_standard_asite_disp_length.txt 
-$ ln -s $HOME/riboviz/data/yeast_tRNAs.tsv 
+$ ln -s $HOME/riboviz/data/yeast_CDS_w_250utrs.fa
+$ ln -s $HOME/riboviz/data/yeast_CDS_w_250utrs.gff3
+$ ln -s $HOME/riboviz/data/yeast_codon_pos_i200.RData
+$ ln -s $HOME/riboviz/data/yeast_features.tsv
+$ ln -s $HOME/riboviz/data/yeast_standard_asite_disp_length.txt
+$ ln -s $HOME/riboviz/data/yeast_tRNAs.tsv
 $ cd ../vignette/input
-$ ln -s $HOME/riboviz/vignette/input/SRR1042855_s1mi.fastq.gz 
-$ ln -s $HOME/riboviz/vignette/input/SRR1042864_s1mi.fastq.gz 
-$ ln -s $HOME/riboviz/vignette/input/yeast_rRNA_R64-1-1.fa 
-$ ln -s $HOME/riboviz/vignette/input/yeast_YAL_CDS_w_250utrs.fa 
+$ ln -s $HOME/riboviz/vignette/input/SRR1042855_s1mi.fastq.gz
+$ ln -s $HOME/riboviz/vignette/input/SRR1042864_s1mi.fastq.gz
+$ ln -s $HOME/riboviz/vignette/input/yeast_rRNA_R64-1-1.fa
+$ ln -s $HOME/riboviz/vignette/input/yeast_YAL_CDS_w_250utrs.fa
 $ ln -s $HOME/riboviz/vignette/input/yeast_YAL_CDS_w_250utrs.gff3
 $ cd ../..
 $ ls

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1184,7 +1184,7 @@ process generateStatsFigs {
         tuple val(sample_id), file("startcodon_ribogrid.pdf") \
             optional true into start_codon_ribogrid_pdf
         tuple val(sample_id), file("codon_ribodens.pdf") \
-            optional (! (is_t_rna_and_codon_positions_file && output_pdfs)) \
+            optional (! (is_t_rna_and_codon_positions_file && params.output_pdfs)) \
             into codon_ribodens_pdf
         tuple val(sample_id), file("codon_ribodens.tsv") \
             optional (! is_t_rna_and_codon_positions_file) \
@@ -1193,7 +1193,7 @@ process generateStatsFigs {
             optional (! is_t_rna_and_codon_positions_file) \
             into codon_ribodens_gathered_tsv
         tuple val(sample_id), file("features.pdf") \
-            optional (! (is_features_file && output_pdfs)) into features_pdf
+            optional (! (is_features_file && params.output_pdfs)) into features_pdf
         tuple val(sample_id), file("sequence_features.tsv") \
             optional (! is_features_file) into sequence_features_tsv
         tuple val(sample_id), file("3ntframe_bygene.tsv") \
@@ -1203,7 +1203,7 @@ process generateStatsFigs {
             optional (! is_asite_disp_length_file) \
             into nt3frame_bygene_filtered_tsv
         tuple val(sample_id), file("3ntframe_propbygene.pdf") \
-            optional (! (is_asite_disp_length_file && output_pdfs)) \
+            optional (! (is_asite_disp_length_file && params.output_pdfs)) \
             into nt3frame_propbygene_pdf
     shell:
         t_rna_flag = is_t_rna_and_codon_positions_file \

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1163,7 +1163,7 @@ process generateStatsFigs {
         val sample_id into finished_sample_id
         tuple val(sample_id), file("tpms.tsv") into tpms_tsv
         tuple val(sample_id), file("3nt_periodicity.pdf") \
-            optional true into nt3_periodicity_pdf
+            optional params.output_pdfs into nt3_periodicity_pdf
         tuple val(sample_id), file("3nt_periodicity.tsv") \
             into nt3_periodicity_tsv
         tuple val(sample_id), file("gene_position_length_counts_5start.tsv") \
@@ -1172,17 +1172,17 @@ process generateStatsFigs {
             optional (! params.do_pos_sp_nt_freq) \
             into pos_sp_nt_freq_tsv
         tuple val(sample_id), file("pos_sp_rpf_norm_reads.pdf") \
-            optional true into pos_sp_rpf_norm_reads_pdf
+            optional params.output_pdfs into pos_sp_rpf_norm_reads_pdf
         tuple val(sample_id), file("pos_sp_rpf_norm_reads.tsv") \
             into pos_sp_rpf_norm_reads_tsv
         tuple val(sample_id), file("read_lengths.pdf") \
-            optional true into read_lengths_pdf
+            optional params.output_pdfs into read_lengths_pdf
         tuple val(sample_id), file("read_lengths.tsv") \
             into read_lengths_tsv
         tuple val(sample_id), file("startcodon_ribogridbar.pdf") \
-            optional true into start_codon_ribogridbar_pdf
+            optional params.output_pdfs into start_codon_ribogridbar_pdf
         tuple val(sample_id), file("startcodon_ribogrid.pdf") \
-            optional true into start_codon_ribogrid_pdf
+            optional params.output_pdfs into start_codon_ribogrid_pdf
         tuple val(sample_id), file("codon_ribodens.pdf") \
             optional (! (is_t_rna_and_codon_positions_file && params.output_pdfs)) \
             into codon_ribodens_pdf

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1184,8 +1184,8 @@ process generateStatsFigs {
         tuple val(sample_id), file("startcodon_ribogrid.pdf") \
             optional true into start_codon_ribogrid_pdf
         tuple val(sample_id), file("codon_ribodens.pdf") \
-            optional (! is_t_rna_and_codon_positions_file) \
-            optional true into codon_ribodens_pdf
+            optional (! (is_t_rna_and_codon_positions_file && output_pdfs)) \
+            into codon_ribodens_pdf
         tuple val(sample_id), file("codon_ribodens.tsv") \
             optional (! is_t_rna_and_codon_positions_file) \
             into codon_ribodens_tsv
@@ -1193,7 +1193,7 @@ process generateStatsFigs {
             optional (! is_t_rna_and_codon_positions_file) \
             into codon_ribodens_gathered_tsv
         tuple val(sample_id), file("features.pdf") \
-            optional (! is_features_file) optional true into features_pdf
+            optional (! (is_features_file && output_pdfs)) into features_pdf
         tuple val(sample_id), file("sequence_features.tsv") \
             optional (! is_features_file) into sequence_features_tsv
         tuple val(sample_id), file("3ntframe_bygene.tsv") \
@@ -1203,8 +1203,8 @@ process generateStatsFigs {
             optional (! is_asite_disp_length_file) \
             into nt3frame_bygene_filtered_tsv
         tuple val(sample_id), file("3ntframe_propbygene.pdf") \
-            optional (! is_asite_disp_length_file) \
-            optional true into nt3frame_propbygene_pdf
+            optional (! (is_asite_disp_length_file && output_pdfs)) \
+            into nt3frame_propbygene_pdf
     shell:
         t_rna_flag = is_t_rna_and_codon_positions_file \
             ? "--t-rna-file=${t_rna_tsv}" : ''

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -201,6 +201,7 @@ def helpMessage() {
     Visualization parameters:
 
     * 'run_static_html': run static html visualization per sample? (default 'TRUE')
+    * 'output_pdfs': generate .pdfs for sample-related plots (default 'TRUE')
 
     General:
 
@@ -327,6 +328,7 @@ params.max_read_length = 50
 params.min_read_length = 10
 params.multiplex_fq_files = []
 params.num_processes = 1
+params.output_pdfs = true
 params.publish_index_tmp = false
 params.primary_id = "Name"
 params.rpf = true

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1163,7 +1163,7 @@ process generateStatsFigs {
         val sample_id into finished_sample_id
         tuple val(sample_id), file("tpms.tsv") into tpms_tsv
         tuple val(sample_id), file("3nt_periodicity.pdf") \
-            optional params.output_pdfs into nt3_periodicity_pdf
+            optional (! params.output_pdfs) into nt3_periodicity_pdf
         tuple val(sample_id), file("3nt_periodicity.tsv") \
             into nt3_periodicity_tsv
         tuple val(sample_id), file("gene_position_length_counts_5start.tsv") \
@@ -1172,17 +1172,17 @@ process generateStatsFigs {
             optional (! params.do_pos_sp_nt_freq) \
             into pos_sp_nt_freq_tsv
         tuple val(sample_id), file("pos_sp_rpf_norm_reads.pdf") \
-            optional params.output_pdfs into pos_sp_rpf_norm_reads_pdf
+            optional (! params.output_pdfs) into pos_sp_rpf_norm_reads_pdf
         tuple val(sample_id), file("pos_sp_rpf_norm_reads.tsv") \
             into pos_sp_rpf_norm_reads_tsv
         tuple val(sample_id), file("read_lengths.pdf") \
-            optional params.output_pdfs into read_lengths_pdf
+            optional (! params.output_pdfs) into read_lengths_pdf
         tuple val(sample_id), file("read_lengths.tsv") \
             into read_lengths_tsv
         tuple val(sample_id), file("startcodon_ribogridbar.pdf") \
-            optional params.output_pdfs into start_codon_ribogridbar_pdf
+            optional (! params.output_pdfs) into start_codon_ribogridbar_pdf
         tuple val(sample_id), file("startcodon_ribogrid.pdf") \
-            optional params.output_pdfs into start_codon_ribogrid_pdf
+            optional (! params.output_pdfs) into start_codon_ribogrid_pdf
         tuple val(sample_id), file("codon_ribodens.pdf") \
             optional (! (is_t_rna_and_codon_positions_file && params.output_pdfs)) \
             into codon_ribodens_pdf

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1163,7 +1163,7 @@ process generateStatsFigs {
         val sample_id into finished_sample_id
         tuple val(sample_id), file("tpms.tsv") into tpms_tsv
         tuple val(sample_id), file("3nt_periodicity.pdf") \
-            into nt3_periodicity_pdf
+            optional true into nt3_periodicity_pdf
         tuple val(sample_id), file("3nt_periodicity.tsv") \
             into nt3_periodicity_tsv
         tuple val(sample_id), file("gene_position_length_counts_5start.tsv") \
@@ -1172,20 +1172,20 @@ process generateStatsFigs {
             optional (! params.do_pos_sp_nt_freq) \
             into pos_sp_nt_freq_tsv
         tuple val(sample_id), file("pos_sp_rpf_norm_reads.pdf") \
-            into pos_sp_rpf_norm_reads_pdf
+            optional true into pos_sp_rpf_norm_reads_pdf
         tuple val(sample_id), file("pos_sp_rpf_norm_reads.tsv") \
             into pos_sp_rpf_norm_reads_tsv
         tuple val(sample_id), file("read_lengths.pdf") \
-            into read_lengths_pdf
+            optional true into read_lengths_pdf
         tuple val(sample_id), file("read_lengths.tsv") \
             into read_lengths_tsv
         tuple val(sample_id), file("startcodon_ribogridbar.pdf") \
-            into start_codon_ribogridbar_pdf
+            optional true into start_codon_ribogridbar_pdf
         tuple val(sample_id), file("startcodon_ribogrid.pdf") \
-            into start_codon_ribogrid_pdf
+            optional true into start_codon_ribogrid_pdf
         tuple val(sample_id), file("codon_ribodens.pdf") \
             optional (! is_t_rna_and_codon_positions_file) \
-            into codon_ribodens_pdf
+            optional true into codon_ribodens_pdf
         tuple val(sample_id), file("codon_ribodens.tsv") \
             optional (! is_t_rna_and_codon_positions_file) \
             into codon_ribodens_tsv
@@ -1193,7 +1193,7 @@ process generateStatsFigs {
             optional (! is_t_rna_and_codon_positions_file) \
             into codon_ribodens_gathered_tsv
         tuple val(sample_id), file("features.pdf") \
-            optional (! is_features_file) into features_pdf
+            optional (! is_features_file) optional true into features_pdf
         tuple val(sample_id), file("sequence_features.tsv") \
             optional (! is_features_file) into sequence_features_tsv
         tuple val(sample_id), file("3ntframe_bygene.tsv") \
@@ -1204,7 +1204,7 @@ process generateStatsFigs {
             into nt3frame_bygene_filtered_tsv
         tuple val(sample_id), file("3ntframe_propbygene.pdf") \
             optional (! is_asite_disp_length_file) \
-            into nt3frame_propbygene_pdf
+            optional true into nt3frame_propbygene_pdf
     shell:
         t_rna_flag = is_t_rna_and_codon_positions_file \
             ? "--t-rna-file=${t_rna_tsv}" : ''

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1226,6 +1226,7 @@ process generateStatsFigs {
            --dataset=${params.dataset} \
            --hd-file=${sample_h5} \
            --orf-fasta-file=${orf_fasta} \
+           --output-pdfs=${params.output_pdfs} \
            --rpf=${params.rpf} \
            --output-dir=. \
            --do-pos-sp-nt-freq=${params.do_pos_sp_nt_freq} \

--- a/riboviz/params.py
+++ b/riboviz/params.py
@@ -11,6 +11,9 @@ TMP_DIR = "dir_tmp"
 OUTPUT_DIR = "dir_out"
 """ Output files directory. """
 
+OUTPUT_PDFS = "output_pdfs"
+""" Generate .pdfs for sample-related plots. """
+
 ORF_FASTA_FILE = "orf_fasta_file"
 """ ORF file to align to. """
 ORF_GFF_FILE = "orf_gff_file"

--- a/riboviz/test/config/vignette_config_current.yaml
+++ b/riboviz/test/config/vignette_config_current.yaml
@@ -42,6 +42,7 @@ num_processes: 1
 orf_fasta_file: vignette/input/yeast_YAL_CDS_w_250utrs.fa
 orf_gff_file: vignette/input/yeast_YAL_CDS_w_250utrs.gff3
 orf_index_prefix: YAL_CDS_w_250
+output_pdfs: TRUE
 primary_id: Name
 publish_index_tmp: FALSE
 rpf: TRUE

--- a/riboviz/test/regression/conftest.py
+++ b/riboviz/test/regression/conftest.py
@@ -192,6 +192,7 @@ def pytest_generate_tests(metafunc):
         "index_dir": [config[params.INDEX_DIR]],
         "tmp_dir": [config[params.TMP_DIR]],
         "output_dir": [config[params.OUTPUT_DIR]],
+	"output_pdfs": [utils.value_in_dict(params.OUTPUT_PDFS, config)],
         "extract_umis": [utils.value_in_dict(params.EXTRACT_UMIS, config)],
         "dedup_umis": [utils.value_in_dict(params.DEDUP_UMIS, config)],
         "dedup_stats": [True if params.DEDUP_STATS not in config else utils.value_in_dict(params.DEDUP_STATS, config)],

--- a/riboviz/test/regression/test_regression.py
+++ b/riboviz/test/regression/test_regression.py
@@ -660,7 +660,7 @@ def test_generate_stats_figs_tsv(expected_fixture, output_dir, sample,
                           workflow_r.START_CODON_RIBOGRID_PDF,
                           workflow_r.THREE_NT_FRAME_PROP_BY_GENE_PDF])
 def test_generate_stats_figs_pdf(expected_fixture, output_dir, sample,
-                                 file_name):
+                                 file_name, output_pdfs):
     """
     Test ``generate_stats_figs.R`` PDF files exist.
 
@@ -672,7 +672,11 @@ def test_generate_stats_figs_pdf(expected_fixture, output_dir, sample,
     :type sample: str or unicode
     :param file_name: file name
     :type file_name: str or unicode
+    :param output_pdfs: Whether pdfs will be generated
+    :type output_pdfs: bool
     """
+    if not output_pdfs:
+	    pytest.skip('Skipped testing for pdfs as pdfs not generated')
     output_dir_name = os.path.basename(os.path.normpath(output_dir))
     expected_file = os.path.join(expected_fixture, output_dir_name,
                                  sample, file_name)

--- a/riboviz/upgrade_config.py
+++ b/riboviz/upgrade_config.py
@@ -50,6 +50,7 @@ configuration:
 * ``nextflow_timeline_file: nextflow-timeline.html``
 * ``nextflow_trace_file: nextflow-trace.tsv``
 * ``nextflow_work_dir: work``
+* ``output_pdfs: true``
 * ``publish_index_tmp: false``
 * ``run_static_html: true``
 * ``sample_sheet: null``
@@ -123,6 +124,7 @@ UPDATES = {
     params.FQ_FILES: None,
     params.GROUP_UMIS: False,
     params.MULTIPLEX_FQ_FILES: None,
+    params.OUTPUT_PDFS: True,
     params.PUBLISH_INDEX_TMP: False,
     params.RUN_STATIC_HTML: True,
     params.SAMPLE_SHEET: None,

--- a/rscripts/generate_stats_figs.R
+++ b/rscripts/generate_stats_figs.R
@@ -42,6 +42,10 @@ option_list <- list(
               type = "character", default = NA,
               help = "riboviz generated GFF2/GFF3 annotation file"
   ),
+  make_option("--output-pdfs",
+              type = "logical", default = TRUE,
+              help = "generate .pdfs for sample-related plots"
+  ),
   make_option("--num-processes",
               type = "integer", default = 1,
               help = "Number of cores for parallelization"
@@ -184,24 +188,26 @@ ThreeNucleotidePeriodicity <- function(gene_names, dataset, hd_file, gff_df) {
   gene_poslen_counts_5start_df <- CalculateGenePositionLengthCounts5Start(gene_names = gene_names, dataset = dataset, hd_file = hd_file, gff_df = gff_df)
   
   # PlotThreeNucleotidePeriodicity()
-  three_nucleotide_periodicity_plot <- PlotThreeNucleotidePeriodicity(three_nucleotide_periodicity_data)
-
-  # run PlotStartCodonRiboGrid()
-  start_codon_ribogrid_plot <- PlotStartCodonRiboGrid(gene_poslen_counts_5start_df)
-  # creates plot object
-
-  # run SaveStartCodonRiboGrid():
-  SaveStartCodonRiboGrid(start_codon_ribogrid_plot)
-
-  # run PlotStartCodonRiboGridBar():
-  start_codon_ribogrid_bar_plot <- PlotStartCodonRiboGridBar(gene_poslen_counts_5start_df)
-  # creates plot object
-
-  # run SaveStartCodonRiboGridBar():
-  SaveStartCodonRiboGridBar(start_codon_ribogrid_bar_plot)
-
-  # run SavePlotThreeNucleotidePeriodicity():
-  SavePlotThreeNucleotidePeriodicity(three_nucleotide_periodicity_plot)
+  if(output_pdfs){
+    three_nucleotide_periodicity_plot <- PlotThreeNucleotidePeriodicity(three_nucleotide_periodicity_data)
+    
+    # run PlotStartCodonRiboGrid()
+    start_codon_ribogrid_plot <- PlotStartCodonRiboGrid(gene_poslen_counts_5start_df)
+    # creates plot object
+    
+    # run SaveStartCodonRiboGrid():
+    SaveStartCodonRiboGrid(start_codon_ribogrid_plot)
+    
+    # run PlotStartCodonRiboGridBar():
+    start_codon_ribogrid_bar_plot <- PlotStartCodonRiboGridBar(gene_poslen_counts_5start_df)
+    # creates plot object
+    
+    # run SaveStartCodonRiboGridBar():
+    SaveStartCodonRiboGridBar(start_codon_ribogrid_bar_plot)
+    
+    # run SavePlotThreeNucleotidePeriodicity():
+    SavePlotThreeNucleotidePeriodicity(three_nucleotide_periodicity_plot)
+  } 
 
   # run WriteThreeNucleotidePeriodicity():
   WriteThreeNucleotidePeriodicity(three_nucleotide_periodicity_data)
@@ -229,13 +235,15 @@ DistributionOfLengthsMappedReads <- function(gene_names, dataset, hd_file){
   # run CalculateReadLengths():
   read_length_data <- CalculateReadLengths(gene_names, dataset, hd_file)
 
-  # run PlotReadLengths():
-  read_len_plot <- PlotReadLengths(read_length_data)
-  # creates plot object
-
-  # to run SavePlotReadLenths():
-  SavePlotReadLengths(read_len_plot)
-
+  if(output_pdfs){
+    # run PlotReadLengths():
+    read_len_plot <- PlotReadLengths(read_length_data)
+    # creates plot object
+    
+    # to run SavePlotReadLenths():
+    SavePlotReadLengths(read_len_plot)
+  }
+  
   # to run WriteReadLengths():
   WriteReadLengths(read_length_data)
 
@@ -311,12 +319,14 @@ if (!is.na(asite_disp_length_file)) {
   # filter gene_read_frames_data to remove counts over the count_threshold
   gene_read_frame_data_filtered <- FilterGeneReadFrames(gene_read_frames_data, count_threshold)
   
-  # run PlotGeneReadFrames():
-  gene_read_frame_plot <- PlotGeneReadFrames(gene_read_frame_data_filtered)
-  # creates plot object
-
-  # run SaveGeneReadFrames():
-  SaveGeneReadFrames(gene_read_frame_plot)
+  if(output_pdfs){
+    # run PlotGeneReadFrames():
+    gene_read_frame_plot <- PlotGeneReadFrames(gene_read_frame_data_filtered)
+    # creates plot object
+    
+    # run SaveGeneReadFrames():
+    SaveGeneReadFrames(gene_read_frame_plot)
+  }
 
   # run WriteFilteredGeneReadFrames():
   WriteFilteredGeneReadFrames(gene_read_frame_data_filtered)
@@ -342,9 +352,11 @@ if (rpf) {
   
   pos_sp_rpf_norm_reads_data <- CalculatePositionSpecificDistributionOfReads(gene_names, dataset, hd_file, buffer, min_read_length, count_threshold)
   
-  pos_sp_rpf_norm_reads_plot <- PlotPositionSpecificDistributionOfReads(pos_sp_rpf_norm_reads_data)
-  
-  SavePositionSpecificDistributionOfReads(pos_sp_rpf_norm_reads_plot)
+  if(output_pdfs){
+    pos_sp_rpf_norm_reads_plot <- PlotPositionSpecificDistributionOfReads(pos_sp_rpf_norm_reads_data)
+    
+    SavePositionSpecificDistributionOfReads(pos_sp_rpf_norm_reads_plot)
+  }
 
   WritePositionSpecificDistributionOfReads(pos_sp_rpf_norm_reads_data)
 
@@ -373,11 +385,13 @@ if (!rpf) {
   # calculate
   pos_sp_mrna_norm_coverage <- CalculateNucleotideBasedPositionSpecificReadsMRNA(gene_names, dataset, min_read_length, read_range, buffer)
   
-  # plot
-  PlotNucleotideBasedPositionSpecificReadsPerGeneMRNA(pos_sp_mrna_norm_coverage)
-  
-  # save plot out
-  SaveNucleotideBasedPositionSpecificReadsPerGeneMRNA(pos_sp_mrna_norm_coverage_plot)
+  if(output_pdfs){
+    # plot
+    PlotNucleotideBasedPositionSpecificReadsPerGeneMRNA(pos_sp_mrna_norm_coverage)
+    
+    # save plot out
+    SaveNucleotideBasedPositionSpecificReadsPerGeneMRNA(pos_sp_mrna_norm_coverage_plot)
+  }
   
   # write file out
   WriteNucleotideBasedPositionSpecificReadsPerGeneMRNA(pos_sp_mrna_norm_coverage)
@@ -435,9 +449,11 @@ if (!is.na(features_file)) { # do correlating
 
   features_plot_data <- CalculateSequenceBasedFeatures(features, tpms)
 
-  features_plot <- PlotSequenceBasedFeatures(features_plot_data)
-  
-  SaveSequenceBasedFeatures(features_plot)
+  if (output_pdfs){
+    features_plot <- PlotSequenceBasedFeatures(features_plot_data)
+    
+    SaveSequenceBasedFeatures(features_plot)
+  }
 
   WriteSequenceBasedFeatures(features_plot_data)
 
@@ -463,9 +479,11 @@ if (!is.na(t_rna_file) & !is.na(codon_positions_file)) {
     
     cod_dens_tRNA_wide <- GatherCodonSpecificRibosomeDensityTRNACorrelation(cod_dens_tRNA_data)
     
-    cod_dens_tRNA_plot <- PlotCodonSpecificRibosomeDensityTRNACorrelation(cod_dens_tRNA_wide)
-
-    SaveCodonSpecificRibosomeDensityTRNACorrelation(cod_dens_tRNA_plot)
+    if(output_pdfs){
+      cod_dens_tRNA_plot <- PlotCodonSpecificRibosomeDensityTRNACorrelation(cod_dens_tRNA_wide)
+      
+      SaveCodonSpecificRibosomeDensityTRNACorrelation(cod_dens_tRNA_plot)
+    }
     
     WriteGatheredCodonSpecificRibosomeDensityTRNACorrelation(cod_dens_tRNA_wide)
     

--- a/vignette/remote_vignette_config.yaml
+++ b/vignette/remote_vignette_config.yaml
@@ -30,6 +30,7 @@ num_processes: 1 # Number of processes to parallelize over
 orf_fasta_file: remote-vignette/input/yeast_YAL_CDS_w_250utrs.fa # ORF file to align to
 orf_gff_file: remote-vignette/input/yeast_YAL_CDS_w_250utrs.gff3  # GFF2/GFF3 file for ORFs
 orf_index_prefix: YAL_CDS_w_250 # ORF index file prefix, relative to dir_index
+output_pdfs: TRUE # generate .pdfs for sample-related plots 
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)
 rpf: TRUE # Is the dataset an RPF or mRNA dataset?
 rrna_fasta_file: remote-vignette/input/yeast_rRNA_R64-1-1.fa # rRNA file to avoid aligning to

--- a/vignette/simdata_multiplex_config.yaml
+++ b/vignette/simdata_multiplex_config.yaml
@@ -40,6 +40,7 @@ num_processes: 1 # Number of processes to parallelize over
 orf_fasta_file: vignette/input/yeast_YAL_CDS_w_250utrs.fa # ORF file to align to
 orf_gff_file: vignette/input/yeast_YAL_CDS_w_250utrs.gff3 # GFF2/GFF3 file for ORFs
 orf_index_prefix: YAL_CDS_w_250 # ORF index file prefix, relative to dir_index
+output_pdfs: TRUE # generate .pdfs for sample-related plots 
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)
 publish_index_tmp: FALSE # Publish index and temporary files to dir_index and dir_tmp? If FALSE, use symlinks.
 rpf: TRUE # Is the dataset an RPF or mRNA dataset?

--- a/vignette/simdata_umi_config.yaml
+++ b/vignette/simdata_umi_config.yaml
@@ -39,7 +39,8 @@ nextflow_work_dir: work # Nextflow work directory (job submission).
 num_processes: 1 # Number of processes to parallelize over
 orf_fasta_file: vignette/input/yeast_YAL_CDS_w_250utrs.fa # ORF file to align to
 orf_gff_file: vignette/input/yeast_YAL_CDS_w_250utrs.gff3 # GFF2/GFF3 file for ORFs
-orf_index_prefix: YAL_CDS_w_250 # ORF index file prefix, relative to dir_index
+orf_index_prefix: YAL_CDS_w_250 # ORF index file prefix, relative to dir_index 
+output_pdfs: TRUE # generate .pdfs for sample-related plots 
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)
 publish_index_tmp: FALSE # Publish index and temporary files to dir_index and dir_tmp? If FALSE, use symlinks.
 rpf: TRUE # Is the dataset an RPF or mRNA dataset?

--- a/vignette/vignette_config.yaml
+++ b/vignette/vignette_config.yaml
@@ -41,7 +41,8 @@ nextflow_work_dir: work # Nextflow work directory (job submission).
 num_processes: 1 # Number of processes to parallelize over
 orf_fasta_file: vignette/input/yeast_YAL_CDS_w_250utrs.fa # ORF file to align to
 orf_gff_file: vignette/input/yeast_YAL_CDS_w_250utrs.gff3 # GFF2/GFF3 file for ORFs
-orf_index_prefix: YAL_CDS_w_250 # ORF index file prefix, relative to dir_index
+orf_index_prefix: YAL_CDS_w_250 # ORF index file prefix, relative to dir_index 
+output_pdfs: TRUE # generate .pdfs for sample-related plots 
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)
 publish_index_tmp: FALSE # Publish index and temporary files to dir_index and dir_tmp? If FALSE, use symlinks.
 rpf: TRUE # Is the dataset an RPF or mRNA dataset?


### PR DESCRIPTION
Adds new config yaml parameter `output_pdfs` (currently TRUE by default). 

This parameter controls generation of the per-sample PDF plots. 

Integration tests are only run to check PDFs if `output_pdfs` is TRUE, otherwise, these tests are skipped. 

No additional packages or installation changes, just be aware of the new parameter to the config file. 

Latest develop merged in (last commit in merged develop was 4ecf1a929, PR 365 merge for rename master main). 

This PR resolves #317 