### PR TITLE
Trna plot 363

### DIFF
--- a/rscripts/stats_figs_block_functions.R
+++ b/rscripts/stats_figs_block_functions.R
@@ -812,7 +812,7 @@ WriteSequenceBasedFeatures <- function(features_plot_data){
 CalculateCodonSpecificRibosomeDensity <- function(t_rna_file, codon_positions_file, gene_names, hd_file, dataset, buffer, count_threshold){
   
   # This still depends on yeast-specific arguments and should be edited.
-  yeast_tRNAs <- read.table(t_rna_file, h = T) # Read in yeast tRNA estimates
+  trna <- read.table(t_rna_file, h = T) # Read in yeast tRNA estimates
   load(codon_positions_file) # Position of codons in each gene (numbering ignores first 200 codons)
   # Reads in an object named "codon_pos"
   
@@ -859,9 +859,8 @@ CalculateCodonSpecificRibosomeDensity <- function(t_rna_file, codon_positions_fi
   A <- a_mn[order(names(codon_pos))]
   P <- p_mn[order(names(codon_pos))]
   E <- e_mn[order(names(codon_pos))]
-  
-  cod_dens_tRNA_data <- cbind(yeast_tRNAs, A, P, E)
-  
+  trna <- trna[order(trna$Codon),]
+  cod_dens_tRNA_data <- cbind(trna, A, P, E)
   return(cod_dens_tRNA_data)
   
 } # end of CalculateCodonSpecificRibosomeDensity() definition
@@ -870,9 +869,8 @@ CalculateCodonSpecificRibosomeDensity <- function(t_rna_file, codon_positions_fi
 GatherCodonSpecificRibosomeDensityTRNACorrelation <- function(cod_dens_tRNA_data) {
   # Prepare data for plot
   cod_dens_tRNA_wide <- cod_dens_tRNA_data %>%
-    gather(tRNA_type, tRNA_value, 3:6) %>%
-    gather(Site, Ribodens, 3:5)
-  
+     pivot_longer(!c(AA,Codon,A,P,E),names_to="tRNA_type",values_to="tRNA_value") %>% 
+     pivot_longer(c(A,P,E),names_to="Site",values_to="Ribodens")
   return(cod_dens_tRNA_wide)
 } 
 


### PR DESCRIPTION
This pull requests updates code involved in comparing codon-specific ribosome densities with metrics related to tRNA abundance. The previous implementation had hard-coded values which worked because we've primarily applied this functionality to _S. cerevisiae_, which has a tRNA file in `data/yeast_tRNA.tsv`. When applying this to a file that has a different number of columns, the code breaks during the plotting. I have updated these functions in two ways. (1) Before binding the ribosome density estimates (columns A, P, and E) with the tRNA data frame, make sure the tRNA data frame is also in alphabetical order by codon. In the future, I think it would be safer to make this into a join operation (what if the input tRNA file doesn't have a value for all codons), but this seems like a satisfactory solution for now. (2) I have modified the function going from a wide to long data frame to use `pivot_longer` as opposed to `gather`. This is where the hard-coded values were causing me problems. The code now first pivots the tRNA metrics, which is anything that isn't the amino acid, codon, or A, P, E sites, and then pivots on the A, P, and E sites. Need to improve documentation to make sure the expected file formats for the tRNA files is clear to users.      


Below are the results of the unit tests and integration tests. The integration tests were performed using the results from `regression-test-data-20210119`. The `PendingDeprecationWarning` and the `AssertionErrors` due to the H5 file are expected, in this case, and are thus ignored. 


**Results of Python tests:**

```
pytest --ignore-glob="*integration*"
==================================================================== test session starts =====================================================================
platform linux -- Python 3.7.8, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /data/cope/riboviz
collected 392 items                                                                                                                                          

riboviz/test/test_barcodes_umis.py .................                                                                                                   [  4%]
riboviz/test/test_check_fasta_gff.py ........................                                                                                          [ 10%]
riboviz/test/test_create_job_script.py .................                                                                                               [ 14%]
riboviz/test/test_demultiplex_fastq.py ..................                                                                                              [ 19%]
riboviz/test/test_environment.py .......................................................................                                               [ 37%]
riboviz/test/test_fastq.py ........................                                                                                                    [ 43%]
riboviz/test/test_get_cds_codons.py ........................................                                                                           [ 53%]
riboviz/test/test_process_utils.py ........................                                                                                            [ 59%]
riboviz/test/test_sam_bam.py ................                                                                                                          [ 64%]
riboviz/test/test_sample_sheet.py ..........                                                                                                           [ 66%]
riboviz/test/test_trim_5p_mismatch.py ............                                                                                                     [ 69%]
riboviz/test/test_upgrade_config.py ....                                                                                                               [ 70%]
riboviz/test/test_utils.py ..........................                                                                                                  [ 77%]
riboviz/test/nextflow/test_configuration.py ..................                                                                                         [ 81%]
riboviz/test/nextflow/test_simdata_multiplex.py ..............                                                                                         [ 85%]
riboviz/test/nextflow/test_simdata_umi.py .......                                                                                                      [ 87%]
riboviz/test/nextflow/test_validation.py ..................................................                                                            [100%]

====================================================================== warnings summary ======================================================================
/home/cope/miniconda3/envs/riboviz/lib/python3.7/site-packages/Bio/Alphabet/__init__.py:27
  /home/cope/miniconda3/envs/riboviz/lib/python3.7/site-packages/Bio/Alphabet/__init__.py:27: PendingDeprecationWarning: We intend to remove or replace Bio.Alphabet in 2020, ideally avoid using it explicitly in your code. Please get in touch if you will be adversely affected by this. https://github.com/biopython/biopython/issues/2046
    PendingDeprecationWarning,

riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta_use_feature_name_true
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta_cds_format
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta_exclude_stop_codons
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file_use_feature_name_true
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file_cds_format
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file_exclude_stop_codons
  /data/cope/riboviz/riboviz/get_cds_codons.py:173: UserWarning: 'YAL003CMissingGene_mRNA not in /data/cope/riboviz/riboviz/test/data/test_get_cds_codons.fasta.'
    warnings.warn(str(e))

riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta_use_feature_name_true
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta_cds_format
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_from_fasta_exclude_stop_codons
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file_use_feature_name_true
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file_cds_format
riboviz/test/test_get_cds_codons.py::test_get_cds_codons_file_exclude_stop_codons
  /data/cope/riboviz/riboviz/get_cds_codons.py:176: UserWarning: Feature YAL007CBadLengthCDS_mRNA (ATGGCCTGTTA) has length not divisible by 3
    warnings.warn(str(e))

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================= 392 passed, 17 warnings in 1308.09s (0:21:48) ========================================================
```

**Results from testthat.R**

```
══ Results ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 136.3 s

[ FAIL 0 | WARN 4 | SKIP 0 | PASS 522 ]

```

**Results of integration tests** 
```

================================================================== short test summary info ===================================================================
FAILED riboviz/test/integration/test_integration.py::test_bam_to_h5_h5[vignette/output-WTnone] - AssertionError: Non-zero return code (1) from h5diff -q /d...
FAILED riboviz/test/integration/test_integration.py::test_bam_to_h5_h5[vignette/output-WT3AT] - AssertionError: Non-zero return code (1) from h5diff -q /da...

```