### PR TITLE
Updated prep_riboviz.nf staticHTML to use intermediate directory

### DIFF
--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -1397,6 +1397,7 @@ process staticHTML {
           script += ", sequence_features_file='\$PWD/${sample_sequence_features_tsv}' "
       }
       script += "), "
+      script += "intermediates_dir = '\$PWD', "
       script += "output_format = 'html_document', "
       script += "output_file = '\$PWD/${sample_id}_output_report.html')"
       """


### PR DESCRIPTION
Updated call to rmarkdown::render in staticHTML to set directory
for intermediate files to be $PWD i.e. work directory for task.
This means that sample-specific intermediate files are created
in sample-specific directories rather than in rmarkdown/ (leading
to intermediate files for different samples colliding as they
all are prefixed by AnalysisOutputs but have no sample-specific
identifier in their name).