### PR TITLE
Remove now-deprecated `stop_in_cds` parameter

### DIFF
--- a/docs/reference/hdf5-data.md
+++ b/docs/reference/hdf5-data.md
@@ -23,8 +23,7 @@ It is passed the following configuration parameters from the RiboViz configurati
 | `orf_gff_file` | Matched genome feature file, specifying coding sequences locations (start and stop coordinates) within the transcripts (GTF/GFF3 file) |
 | `primary_id` | Primary gene IDs to access the data (YAL001C, YAL003W, etc.) |
 | `secondary_id` | Secondary gene IDs to access the data (COX1, EFB1, etc. or `NULL`) |
-| `stop_in_cds` | Are stop codons part of the feature annotations in `orf_gff_file`? If both `stop_in_feature` and `stop_in_cds` are defined then `stop_in_feature` takes precedence. |
-| `stop_in_feature` | Are stop codons part of the feature annotations in `orf_gff_file`? If not provided and `stop_in_cds` is provided then the value of `stop_in_cds` is used for `stop_in_feature`. If both `stop_in_feature` and `stop_in_cds` are defined then `stop_in_feature` takes precedence. |
+| `stop_in_feature` | Are stop codons part of the feature annotations in `orf_gff_file`? |
 
 At present, the default feature is assumed to be `CDS`.
 

--- a/docs/user/prep-riboviz-config.md
+++ b/docs/user/prep-riboviz-config.md
@@ -93,8 +93,7 @@ The workflow also supports the following configuration parameters. All directory
  | `sample_sheet` | A sample sheet, relative to `<dir_in>` (tab-separated values file) | Only if `multiplex_fq_files` is provided | |
 | `secondary_id` | Secondary gene IDs to access the data (COX1, EFB1, etc. or `NULL`) | No | `NULL` |
 | `skip_inputs` | When validating configuration (see `validate_only` below) skip checks for existence of ribosome profiling data files (`fq_files`, `multiplexed_fq_files`, `sample_sheet`)?  | No | `false` |
-| `stop_in_cds` | Are stop codons part of the CDS annotations in GFF? Used by `bam_to_h5.R` only (and only if `is_riboviz_gff` is `false`). Note: this parameter is now deprecated by `stop_in_feature` and will be removed in a future release. If both `stop_in_feature` and `stop_in_cds` are defined then `stop_in_feature` takes precedence. | No | `false` |
-| `stop_in_feature` | Are stop codons part of the feature annotations in GFF? If not provided and `stop_in_cds` is provided then the value of `stop_in_cds` is used for `stop_in_feature`. If both `stop_in_feature` and `stop_in_cds` are defined then `stop_in_feature` takes precedence. | No | `false` |
+| `stop_in_feature` | Are stop codons part of the feature annotations in GFF? | No | `false` |
 | `trim_5p_mismatches` | Trim mismatched 5' base?  | No | `true` |
 | `t_rna_file` | tRNA estimates file (tab-separated values file) | Only if `codon_positions_file` is also provided | |
 | `umi_regexp` | UMI-tools-compliant regular expression to extract barcodes and UMIs. For details on the regular expression format, see UMI-tools documentation on [Barcode extraction](https://umi-tools.readthedocs.io/en/latest/reference/extract.html#barcode-extraction) | Only if `extract_umis` is `true` | |

--- a/prep_riboviz.nf
+++ b/prep_riboviz.nf
@@ -185,18 +185,9 @@ def helpMessage() {
     * 'rpf': Is the dataset an RPF or mRNA dataset? (default 'TRUE')
     * 'secondary_id': Secondary gene IDs to access the data (COX1,
       EFB1, etc. or 'NULL') (default 'NULL')
-    * 'stop_in_cds': Are stop codons part of the CDS annotations in
-      GFF? (default 'FALSE') Used by 'bam_to_h5.R' only (and only
-      if 'is_riboviz_gff' is 'FALSE'). Note: this parameter is now
-      deprecated by 'stop_in_feature' and will be removed in a future
-      release. If both 'stop_in_feature' and 'stop_in_cds' are defined
-      then 'stop_in_feature' takes precedence.
     * 'stop_in_feature': Are stop codons part of the feature
-      annotations in GFF? If not provided and 'stop_in_cds' is
-      provided then the value of 'stop_in_cds' is used for
-      'stop_in_feature'. If both 'stop_in_feature' and 'stop_in_cds'
-      are defined then `stop_in_feature` takes precedence.
-      (default 'FALSE')
+      annotations in GFF? Used by 'bam_to_h5.R' only (and only
+      if 'is_riboviz_gff' is 'FALSE') (default 'FALSE').
 
     Visualization parameters:
 
@@ -334,7 +325,7 @@ params.primary_id = "Name"
 params.rpf = true
 params.run_static_html = true
 params.secondary_id = null
-params.stop_in_cds = false
+params.stop_in_feature = false
 params.samsort_memory = null
 params.validate_only = false
 params.skip_inputs = false
@@ -382,13 +373,6 @@ if (! params.secondary_id) {
     secondary_id = null
 } else {
     secondary_id = params.secondary_id
-}
-if (params.containsKey('stop_in_feature')) {
-    stop_in_feature = params.stop_in_feature
-} else if (params.containsKey('stop_in_cds')) {
-    stop_in_feature = params.stop_in_cds
-} else {
-    stop_in_feature = false
 }
 if (params.dedup_umis) {
     if (! params.extract_umis) {
@@ -1140,7 +1124,7 @@ process bamToH5 {
            --orf-gff-file=${orf_gff} \
            --is-riboviz-gff=${params.is_riboviz_gff} \
            --feature=${params.feature} \
-           --stop-in-feature=${stop_in_feature}
+           --stop-in-feature=${params.stop_in_feature}
         """
 }
 


### PR DESCRIPTION
`stop_in_cds` was deprecated by `stop_in_feature` prior to release 2.1.
This included adding support to `riboviz.upgrade_config` to rename
`stop_in_cds` to `stop_in_feature` in any configuration file.

This commit removes support for `stop_in_cds` from the workflow
and references to it in the documentation.